### PR TITLE
Feature/#15 move cdn make

### DIFF
--- a/src/frontend/index.dev.html
+++ b/src/frontend/index.dev.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>React TypeScript App</title>
+    <script crossorigin="anonymous" src="https://unpkg.com/react@17.0.1/umd/react.development.js"></script>
+    <script crossorigin="anonymous" src="https://unpkg.com/react-dom@17.0.1/umd/react-dom.development.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/webpack.config.dev.ts
+++ b/webpack.config.dev.ts
@@ -68,7 +68,7 @@ const webpackConfig = (env: {
     ],
   },
   plugins: [
-    new HtmlWebpackPlugin({ template: "./src/frontend/index.html" }),
+    new HtmlWebpackPlugin({ template: "./src/frontend/index.dev.html" }),
     new webpack.DefinePlugin({
       "process.env.PRODUCTION": env.production || !env.development,
       "process.env.NAME": JSON.stringify(packageJSON.name),
@@ -78,6 +78,10 @@ const webpackConfig = (env: {
     new webpack.HotModuleReplacementPlugin(),
     new ReactRefreshWebpackPlugin(),
   ],
+  externals: {
+    react: "React",
+    "react-dom": "ReactDOM",
+  },
 });
 
 export default webpackConfig;


### PR DESCRIPTION
#15 への対応。
productionへの対応は完成したときに後でまとめてやるので今は後回し。
React関係はcdnに移しても問題なかったが、その他のReactをベースとしたライブラリ類は名前空間の都合上面倒なことになりそうだったのでやらないことにした。そのあたりはそこまでデータ量がないので、cdnに移してもそこまで変わらないだろう、ということで、リターンが薄いということも判断材料の一つ。