### PR TITLE
fix: bug with same tweets #25

### DIFF
--- a/src/frontend/globalState.ts
+++ b/src/frontend/globalState.ts
@@ -109,12 +109,19 @@ const asyncReducer: GlobalAsyncReducer = {
     });
   },
   GET_TWEETS: ({ dispatch, signal, getState }) => async (action) => {
-    const lastNewestTweetDataId = getState().newestTweetDataId;
+    const {
+      newestTweetDataId: lastNewestTweetDataId,
+      isGettingTweets,
+    } = getState();
     const sendResult =
       action.callback ||
       ((_arg: boolean) => {
         return;
       });
+    if (isGettingTweets) {
+      sendResult(false);
+      return;
+    }
     dispatch({ type: "MODIFY", state: { isGettingTweets: true } });
     const newTweetData = await getNewTweetData(lastNewestTweetDataId);
     // It is to lose no got tweet data without writing to db.


### PR DESCRIPTION
#25 への対応。
修正はしたが、バグ発見時の重複はそもそも連打速度が足りずに再現できなかった。おそらく、コンフィグ周りによるTweetの重複が原因だと思われる。