### PR TITLE
update: showing icon image #35

### DIFF
--- a/src/frontend/components/Tweet/Tweet.tsx
+++ b/src/frontend/components/Tweet/Tweet.tsx
@@ -3,6 +3,7 @@ import React from "react";
 export const Tweet: React.FC<{ tweet: Tweet }> = React.memo((props) => {
   return (
     <div>
+      <img src={props.tweet.iconUrl} alt="icon"></img>
       <div>{props.tweet.iconUrl}</div>
       <div>
         <span>{props.tweet.username}</span>


### PR DESCRIPTION
#35 への対応。
キャッシュはimgタグを挿入するだけで行われるようなので、今回はキャッシュ周りにコードを書かなかった。