### PR TITLE
Feature/#46 extend sample make

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ yarn-error.log
 !/public/empty
 .env
 
-/tests/sampleTweets/sample.json
+/tests/sampleTweets/sample*

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   "scripts": {
     "start": "yarn build && yarn start:backend",
     "start:backend": "yarn tsnode src/backend/index.ts",
-    "start:getSample": "yarn tsnode tests/sampleTweets/getSample.ts",
     "tsnode": "ts-node -r tsconfig-paths/register",
     "watch": "tsc -p tsconfig.json -w",
     "build": "webpack --mode production --env.production --progress",

--- a/src/backend/CONSTVALUE.ts
+++ b/src/backend/CONSTVALUE.ts
@@ -9,5 +9,6 @@ export const CONSTVALUE = {
   CONSUMER_TOKEN_SECRET: process.env.CONSUMER_TOKEN_SECRET as string,
   SAMPLE_LIST_ID: process.env.SAMPLE_LIST_ID as string,
   PORT: (parseInt(process.env.port as string) || 3000) as number,
-  SAMPLE_FILE_PATH: process.cwd() + "/tests/sampleTweets/sample.json",
+  SAMPLE_DIRECTORY: process.cwd() + "/tests/sampleTweets/",
+  SAMPLE_BASE_NAME: "sample",
 };

--- a/src/backend/devApp.ts
+++ b/src/backend/devApp.ts
@@ -1,11 +1,26 @@
+/* eslint-disable camelcase */
 import webpack from "webpack";
 import webpackDevMiddleware from "webpack-dev-middleware";
 import webpackHotMiddleware from "webpack-hot-middleware";
 import getConfigDev from "webpack.config.dev";
 import { app } from "./app";
+import { promises as fs } from "fs";
+import { CONSTVALUE } from "./CONSTVALUE";
+import { getSample } from "src/tests/sampleTweets/getSample";
 
 const config = getConfigDev({ production: false, development: true });
 const compiler = webpack(config);
+
+const SAMPLE_BASE_PATH =
+  CONSTVALUE.SAMPLE_DIRECTORY + CONSTVALUE.SAMPLE_BASE_NAME;
+
+const getLoopThree = (() => {
+  let i = 0;
+  return () => {
+    if (i === 3) i = 0;
+    return i++;
+  };
+})();
 
 export const devApp = app
   .use(
@@ -14,4 +29,34 @@ export const devApp = app
       stats: "errors-only",
     })
   )
-  .use(webpackHotMiddleware(compiler));
+  .use(webpackHotMiddleware(compiler))
+  .get("/api/sample", async (req, res) => {
+    const {
+      list_id_str,
+      forced_update,
+      last_newest_tweet_data_id,
+    } = req.query as Record<string, string>;
+    console.log(req.query);
+    if (last_newest_tweet_data_id == null) {
+      res
+        .status(400)
+        .send({ message: "pass last_newest_tweet_data_id as number" });
+    }
+    if (list_id_str == null) {
+      res.status(400).send({ message: "pass list_id of number" });
+      return;
+    }
+    const sample = forced_update
+      ? await getSample(list_id_str, SAMPLE_BASE_PATH)
+      : await fs
+          .readFile(SAMPLE_BASE_PATH + `-${list_id_str}.json`, {
+            encoding: "utf-8",
+          })
+          .then((content) => JSON.parse(content))
+          .then((result) => {
+            console.log(result);
+            return result;
+          })
+          .catch((_err) => getSample(list_id_str, SAMPLE_BASE_PATH));
+    res.send(sample[getLoopThree()]);
+  });

--- a/src/backend/router.ts
+++ b/src/backend/router.ts
@@ -1,26 +1,6 @@
+/* eslint-disable camelcase */
 import express from "express";
-import fsOrigin from "fs";
-import { CONSTVALUE } from "./CONSTVALUE";
-import Twitter from "twitter";
-import { getSample } from "tests/sampleTweets/getSample";
 import { getNewTweetLows } from "./util";
-
-const fs = fsOrigin.promises;
-
-const twitterApi = new Twitter({
-  access_token_key: CONSTVALUE.ACCESS_TOKEN,
-  access_token_secret: CONSTVALUE.ACCESS_TOKEN_SECRET,
-  consumer_key: CONSTVALUE.CONSUMER_TOKEN,
-  consumer_secret: CONSTVALUE.CONSUMER_TOKEN_SECRET,
-});
-
-const getLoopThree = (() => {
-  let i = 0;
-  return () => {
-    if (i === 3) i = 0;
-    return i++;
-  };
-})();
 
 export const router = express
   .Router()
@@ -29,28 +9,20 @@ export const router = express
     res.send({ response: "pong!" });
   })
   .get("/api/tweets", (req, res) => {
-    const { last_newest_tweet_data_id: lastNewestTweetDataIdQuery } = req.query;
-    const lastNewestTweetDataId = parseInt(
-      lastNewestTweetDataIdQuery as string
-    );
-    if (lastNewestTweetDataId == null)
-      res.status(400).send({ message: "pass last_newest_tweet_data_id" });
-    getNewTweetLows(lastNewestTweetDataId, twitterApi)
+    const { last_newest_tweet_data_id, list_id } = req.query as Record<
+      string,
+      string
+    >;
+    if (last_newest_tweet_data_id == null) {
+      res
+        .status(400)
+        .send({ message: "pass last_newest_tweet_data_id as number" });
+    }
+    if (list_id == null) {
+      res.status(400).send({ message: "pass list_id of number" });
+      return;
+    }
+    getNewTweetLows(last_newest_tweet_data_id, list_id)
       .then((result) => res.send(result))
       .catch((err) => console.log(err));
-  })
-  .get("/api/sample", (req, res) => {
-    fs.readFile(CONSTVALUE.SAMPLE_FILE_PATH, {
-      encoding: "utf-8",
-    })
-      .then((content) => {
-        const samples = JSON.parse(content) as any[];
-        res.send(samples[getLoopThree()]);
-      })
-      .catch((_err) => {
-        console.log(_err);
-        getSample(twitterApi).then((result) =>
-          res.send(result[getLoopThree()])
-        );
-      });
   });

--- a/src/backend/twitterApi.ts
+++ b/src/backend/twitterApi.ts
@@ -1,0 +1,9 @@
+import Twitter from "twitter";
+import { CONSTVALUE } from "./CONSTVALUE";
+
+export const twitterApi = new Twitter({
+  access_token_key: CONSTVALUE.ACCESS_TOKEN,
+  access_token_secret: CONSTVALUE.ACCESS_TOKEN_SECRET,
+  consumer_key: CONSTVALUE.CONSUMER_TOKEN,
+  consumer_secret: CONSTVALUE.CONSUMER_TOKEN_SECRET,
+});

--- a/src/backend/util/getNewTweetLows.ts
+++ b/src/backend/util/getNewTweetLows.ts
@@ -1,19 +1,19 @@
-import Twitter from "twitter";
-import { CONSTVALUE } from "../CONSTVALUE";
 import { makeTweetLow } from "./makeTweetLow";
+import { twitterApi } from "../twitterApi";
 
 export const getNewTweetLows = async (
-  lastNewestTweetDataId: number,
-  twitter: Twitter
+  lastNewestTweetDataId: string,
+  listId: string
 ) => {
-  const response = await twitter.get("lists/statuses", {
-    list_id: CONSTVALUE.SAMPLE_LIST_ID,
-    // include_rts: true,
-    tweet_mode: "extended",
-  });
-  console.log(
-    response.map((e: any) => e.entities.media).filter((e: any) => e)[0][0].sizes
-  );
+  console.log("getNew");
+  const response = (await twitterApi
+    .get("lists/statuses", {
+      list_id: listId,
+      // include_rts: true,
+      tweet_mode: "extended",
+    })
+    .catch((err) => console.log(err))) as any[];
+  console.log(response);
   const lastIndexOldTweetData = (response as any[]).findIndex(
     (e) => e.id === lastNewestTweetDataId
   );

--- a/src/backend/util/makeTweetLow.ts
+++ b/src/backend/util/makeTweetLow.ts
@@ -2,10 +2,9 @@
 import { makeMedia } from "./makeMedia";
 import { removeUrl } from "./removeUrl";
 export const makeTweetLow = (tweetData: any) => {
-  console.log(tweetData);
   const {
     full_text: contentData,
-    id: dataid,
+    id_str: dataid,
     created_at,
     user: { screen_name: userid, name: username, profile_image_url: icon_url },
     entities: { media: mediaData },

--- a/src/frontend/components/ForDev/UpdateButton.tsx
+++ b/src/frontend/components/ForDev/UpdateButton.tsx
@@ -2,9 +2,12 @@ import React from "react";
 import { useUpdate } from "src/src/frontend/globalState";
 
 export const UpdateButton: React.FC = React.memo((_props) => {
+  const inputRef = React.useRef<HTMLInputElement | null>(null);
   const dispatch = useUpdate();
   const getTweets = React.useCallback(() => {
-    dispatch({ type: "GET_TWEETS" });
+    const listId = inputRef.current?.value;
+    if (listId == null || listId.length === 0) return;
+    dispatch({ type: "GET_TWEETS", listId: listId });
   }, [dispatch]);
   const showTweets = React.useCallback(() => {
     dispatch({ type: "LOAD_NEW_TWEETS" });
@@ -25,6 +28,11 @@ export const UpdateButton: React.FC = React.memo((_props) => {
     <div>
       <div>
         <button onClick={getTweets}>get tweets</button>
+        <input
+          placeholder={"put the id you wanna get id"}
+          onSubmit={(e) => console.log(e)}
+          ref={inputRef}
+        ></input>
         <button onClick={showTweets}>show tweets</button>
         <button onClick={updateTweet}>update tweets</button>
         <button onClick={deleteTweet}>delete tweets</button>

--- a/src/frontend/globalState/getTweetLows.ts
+++ b/src/frontend/globalState/getTweetLows.ts
@@ -1,10 +1,15 @@
 import { CONSTVALUE } from "../CONSTVALUE";
 
-export const getTweetLows = async (lastNewestTweetDataId: number) => {
+export const getTweetLows = async (
+  lastNewestTweetDataId: string,
+  listId: string
+) => {
   const tweetResponse = await fetch(
     CONSTVALUE.GET_TWEETS_URL +
       "?last_newest_tweet_data_id=" +
-      lastNewestTweetDataId.toString
+      lastNewestTweetDataId +
+      "&list_id_str=" +
+      listId
   );
   console.log({ tweetResponse });
   return (await tweetResponse.json()) as Tweet[];

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -13,7 +13,7 @@ interface MediaColumns {
 
 interface Tweet {
   id: number;
-  dataid: number;
+  dataid: string;
   username: string;
   userid: string;
   iconUrl: string;
@@ -24,7 +24,7 @@ interface Tweet {
 
 interface TweetColumns {
   id: number;
-  dataid: number;
+  dataid: string;
   username: string;
   userid: string;
   icon_url: string;
@@ -35,11 +35,11 @@ interface TweetColumns {
 
 interface Configs {
   lastTweetId: number;
-  newestTweetDataId: number;
+  newestTweetDataId: string;
 }
 
 interface ConfigColumns {
   id: 0;
   last_tweet_id: number;
-  newest_tweet_data_id: number;
+  newest_tweet_data_id: string;
 }

--- a/tests/sampleTweets/getSample.ts
+++ b/tests/sampleTweets/getSample.ts
@@ -1,18 +1,18 @@
 import fsOrigin from "fs";
-import { CONSTVALUE } from "src/backend/CONSTVALUE";
-import Twitter from "twitter";
 import { getNewTweetLows } from "src/backend/util";
 const fs = fsOrigin.promises;
 
-export const getSample = async (twitterApi: Twitter) => {
-  const tweets = await getNewTweetLows(0, twitterApi);
+export const getSample = async (listId: string, fileBasePath: string) => {
+  console.log({ listId, fileBasePath });
+  const tweets = await getNewTweetLows("", listId);
   const tweetsSplitted = [
     tweets.slice(0, 7),
     tweets.slice(7, 14),
     tweets.slice(14),
   ];
+  // fix up for any samples
   fs.writeFile(
-    "tests/sampleTweets/sample.json",
+    fileBasePath + `-${listId}.json`,
     JSON.stringify(tweetsSplitted),
     {
       encoding: "utf-8",
@@ -20,14 +20,3 @@ export const getSample = async (twitterApi: Twitter) => {
   ).then(() => console.log("sample updated"));
   return tweetsSplitted;
 };
-
-if (require.main === module) {
-  const twitterApi = new Twitter({
-    access_token_key: CONSTVALUE.ACCESS_TOKEN,
-    access_token_secret: CONSTVALUE.ACCESS_TOKEN_SECRET,
-    consumer_key: CONSTVALUE.CONSUMER_TOKEN,
-    consumer_secret: CONSTVALUE.CONSUMER_TOKEN_SECRET,
-  });
-  console.log("run getSample");
-  getSample(twitterApi).catch((e) => console.log(e));
-}


### PR DESCRIPTION
#46 への対応。
書いている途中にID全般の桁が大きすぎるのか、文字列と数値との変換の間で誤差があることを確認した。しかしクエリを投げる以上、文字列で扱わなければならない場面が発生するので、全てのIDを文字列管理で行うことにした。ただし、indexeddbのprimary keyのみnumberを使う。
また今回のlistのIDを用いる要件に従って、一度updateのreducerをコメントアウトしている。