### PR TITLE
Feature/#50 pararell get make

### DIFF
--- a/src/backend/util/getNewTweetLows.ts
+++ b/src/backend/util/getNewTweetLows.ts
@@ -21,5 +21,5 @@ export const getNewTweetLows = async (
     lastIndexOldTweetData < 0
       ? response
       : response.slice(lastIndexOldTweetData + 1);
-  return newTweetData.map((e) => makeTweetLow(e));
+  return newTweetData.map((e) => makeTweetLow(e, listId));
 };

--- a/src/backend/util/makeTweetLow.ts
+++ b/src/backend/util/makeTweetLow.ts
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 import { makeMedia } from "./makeMedia";
 import { removeUrl } from "./removeUrl";
-export const makeTweetLow = (tweetData: any) => {
+export const makeTweetLow = (tweetData: any, listId: string) => {
   const {
     full_text: contentData,
     id_str: dataid,
@@ -26,6 +26,7 @@ export const makeTweetLow = (tweetData: any) => {
     userid,
     username,
     icon_url,
+    list_id: listId,
     media,
   } as const;
 };

--- a/src/frontend/components/Config/Config.tsx
+++ b/src/frontend/components/Config/Config.tsx
@@ -3,6 +3,11 @@ import { useSelector, useUpdate } from "src/frontend/globalState";
 
 export const Config: React.FC = React.memo(() => {
   const listIds = useSelector((state) => state.listIds);
+  const newestTweetDataIdGroup = useSelector(
+    (state) => state.newestTweetDataIdGroup
+  );
+  const lastTweetIdGroup = useSelector((state) => state.lastTweetIdGroup);
+  const tweetGroup = useSelector((state) => state.tweetGroup);
   const inputRef = React.useRef<HTMLInputElement | null>(null);
   const dispatch = useUpdate();
   const handleSubmit = React.useCallback(
@@ -11,10 +16,18 @@ export const Config: React.FC = React.memo(() => {
       if (inputRef.current == null) return;
       const listId = inputRef.current.value;
       if (listId.length === 0) return;
-      dispatch({ type: "MODIFY", state: { listIds: [...listIds, listId] } });
+      dispatch({
+        type: "MODIFY",
+        state: {
+          listIds: [...listIds, listId],
+          newestTweetDataIdGroup: { ...newestTweetDataIdGroup, [listId]: "0" },
+          lastTweetIdGroup: { ...lastTweetIdGroup, [listId]: 0 },
+          tweetGroup: { ...tweetGroup, [listId]: [] },
+        },
+      });
       inputRef.current.value = "";
     },
-    [dispatch, listIds]
+    [dispatch, lastTweetIdGroup, listIds, newestTweetDataIdGroup, tweetGroup]
   );
   console.log({ listIds });
   return (

--- a/src/frontend/components/ForDev/UpdateButton.tsx
+++ b/src/frontend/components/ForDev/UpdateButton.tsx
@@ -2,12 +2,9 @@ import React from "react";
 import { useUpdate } from "src/src/frontend/globalState";
 
 export const UpdateButton: React.FC = React.memo((_props) => {
-  const inputRef = React.useRef<HTMLInputElement | null>(null);
   const dispatch = useUpdate();
   const getTweets = React.useCallback(() => {
-    const listId = inputRef.current?.value;
-    if (listId == null || listId.length === 0) return;
-    dispatch({ type: "GET_TWEETS", listId: listId });
+    dispatch({ type: "GET_TWEETS" });
   }, [dispatch]);
   const showTweets = React.useCallback(() => {
     dispatch({ type: "LOAD_NEW_TWEETS" });
@@ -28,11 +25,6 @@ export const UpdateButton: React.FC = React.memo((_props) => {
     <div>
       <div>
         <button onClick={getTweets}>get tweets</button>
-        <input
-          placeholder={"put the id you wanna get id"}
-          onSubmit={(e) => console.log(e)}
-          ref={inputRef}
-        ></input>
         <button onClick={showTweets}>show tweets</button>
         <button onClick={updateTweet}>update tweets</button>
         <button onClick={deleteTweet}>delete tweets</button>

--- a/src/frontend/components/TimeLine/TimeLine.tsx
+++ b/src/frontend/components/TimeLine/TimeLine.tsx
@@ -5,12 +5,17 @@ import { useStyles } from "./style";
 
 export const TimeLine: React.FC = React.memo((_props) => {
   const isLoading = useSelector((state) => state.isLoadingTweets);
-  const tweets = useSelector((state) => state.tweets);
+  const currentList = useSelector((state) => state.currentList);
+  const tweetGroup = useSelector((state) => state.tweetGroup);
+  const tweets = tweetGroup[currentList];
+  console.log({ tweets, tweetGroup, currentList });
   const classes = useStyles();
   return (
     <div className={classes.root}>
       {isLoading && "Loading..."}
-      {tweets.length > 0 && tweets.map((e, i) => <Tweet key={i} tweet={e} />)}
+      {tweets != null &&
+        tweets.length > 0 &&
+        tweets.map((e, i) => <Tweet key={i} tweet={e} />)}
     </div>
   );
 });

--- a/src/frontend/db.ts
+++ b/src/frontend/db.ts
@@ -9,6 +9,7 @@ const tweetColumnsFirst = [
   "created_at",
   "*media",
   "list_id",
+  "[id+list_id]",
 ];
 
 const configColumnsFirst = [

--- a/src/frontend/db.ts
+++ b/src/frontend/db.ts
@@ -8,6 +8,7 @@ const tweetColumnsFirst = [
   "content",
   "created_at",
   "*media",
+  "list_id",
 ];
 
 const configColumnsFirst = [

--- a/src/frontend/globalState/globalState.ts
+++ b/src/frontend/globalState/globalState.ts
@@ -117,6 +117,7 @@ const asyncReducer: GlobalAsyncReducer = {
             return a;
           }
           count++;
+          console.log(oldTweetGroup);
           a.tweetGroup[listId] = [...oldTweetGroup[listId], ...current];
           a.lastTweetIdGroup[listId] = current[current.length - 1].id;
           return a;
@@ -199,16 +200,16 @@ const asyncReducer: GlobalAsyncReducer = {
     });
   },
   UPDATE_TWEETS: (args) => async (action) => {
-    // adjustFlag("isUpdatingTweets", args, async () => {
-    //   const isSuccessGetting = await new Promise((resolve) =>
-    //     action.dispatch({ type: "GET_TWEETS", callback: resolve as any })
-    //   );
-    //   if (isSuccessGetting)
-    //     await new Promise((resolve) =>
-    //       action.dispatch({ type: "LOAD_NEW_TWEETS", callback: resolve as any })
-    //     );
-    //   return undefined;
-    // });
+    adjustFlag("isUpdatingTweets", args, async () => {
+      const isSuccessGetting = await new Promise((resolve) =>
+        action.dispatch({ type: "GET_TWEETS", callback: resolve as any })
+      );
+      if (isSuccessGetting)
+        await new Promise((resolve) =>
+          action.dispatch({ type: "LOAD_NEW_TWEETS", callback: resolve as any })
+        );
+      return undefined;
+    });
   },
   WRITE_CONFIG: (args) => async () => {
     const configLow = makeConfigLow(args.getState());

--- a/src/frontend/globalState/globalState.ts
+++ b/src/frontend/globalState/globalState.ts
@@ -17,7 +17,7 @@ type Flags = {
 };
 
 type AppData = {
-  tweets: Tweet[];
+  tweets: Record<string, Tweet[]>;
 };
 
 type State = Flags & Configs & AppData;
@@ -184,9 +184,9 @@ const useValue = () => {
       isDeletingConfigs: false,
       isUpdatingTweets: false,
       isWritingConfig: false,
-      lastTweetId: 0,
-      tweets: [],
-      newestTweetDataId: "",
+      lastTweetIdGroup: {},
+      tweets: {},
+      newestTweetDataIdGroup: {},
       listIds: [],
       currentList: "",
     } as State,

--- a/src/frontend/globalState/loadTweets.ts
+++ b/src/frontend/globalState/loadTweets.ts
@@ -1,16 +1,32 @@
 import { db } from "../db";
+import Dexie from "dexie";
 import { makeTweets } from "./makeTweets";
 
-export const loadNewTweets = async (lastTweetId: number): Promise<Tweet[]> => {
-  const newTweetLows = await db.tweets.where("id").above(lastTweetId).toArray();
+export const loadNewTweets = async (
+  lastTweetId: number,
+  listId: string
+): Promise<Tweet[]> => {
+  const newTweetLows = await db.tweets
+    .where("[id+list_id]")
+    // lastweetID may make dobule showing
+    // if it occured, minus one lastTweetId
+    .between([lastTweetId, listId], [Dexie.maxKey, listId])
+    .toArray();
+  console.log("load new tweets");
+  console.log({ newTweetLows });
   if (newTweetLows.length === 0) return [];
   return makeTweets(newTweetLows);
 };
 
-export const loadOldTweets = async (lastTweetId: number): Promise<Tweet[]> => {
+export const loadOldTweets = async (
+  lastTweetId: number,
+  listId: string
+): Promise<Tweet[]> => {
   const newTweetLows = await db.tweets
-    .where("id")
-    .belowOrEqual(lastTweetId)
+    .where("[id+list_id]")
+    // lastweetID may make dobule showing
+    // if it occured, minus one lastTweetId
+    .between([Dexie.minKey, listId], [lastTweetId, listId])
     .toArray();
   if (newTweetLows.length === 0) return [];
   return makeTweets(newTweetLows);

--- a/src/frontend/globalState/loadTweets.ts
+++ b/src/frontend/globalState/loadTweets.ts
@@ -8,9 +8,7 @@ export const loadNewTweets = async (
 ): Promise<Tweet[]> => {
   const newTweetLows = await db.tweets
     .where("[id+list_id]")
-    // lastweetID may make dobule showing
-    // if it occured, minus one lastTweetId
-    .between([lastTweetId, listId], [Dexie.maxKey, listId])
+    .between([lastTweetId + 1, listId], [Dexie.maxKey, listId])
     .toArray();
   console.log("load new tweets");
   console.log({ newTweetLows });
@@ -24,9 +22,7 @@ export const loadOldTweets = async (
 ): Promise<Tweet[]> => {
   const newTweetLows = await db.tweets
     .where("[id+list_id]")
-    // lastweetID may make dobule showing
-    // if it occured, minus one lastTweetId
-    .between([Dexie.minKey, listId], [lastTweetId, listId])
+    .between([Dexie.minKey, listId], [lastTweetId + 1, listId])
     .toArray();
   if (newTweetLows.length === 0) return [];
   return makeTweets(newTweetLows);

--- a/src/frontend/globalState/makeConfigs.ts
+++ b/src/frontend/globalState/makeConfigs.ts
@@ -1,0 +1,9 @@
+export const makeConfigs = (configColumns: ConfigColumns): Configs => {
+  const {
+    current_list: currentList,
+    last_tweet_id_group: lastTweetIdGroup,
+    list_ids: listIds,
+    newest_tweet_data_id_group: newestTweetDataIdGroup,
+  } = configColumns;
+  return { currentList, lastTweetIdGroup, listIds, newestTweetDataIdGroup };
+};

--- a/src/frontend/globalState/makeTweets.ts
+++ b/src/frontend/globalState/makeTweets.ts
@@ -11,6 +11,7 @@ export const makeTweets = async (
       userid,
       dataid,
       username,
+      list_id: listId,
     } = e;
     const media: Media[] | undefined = mediaColumns
       ? mediaColumns.map((e) => {
@@ -18,6 +19,16 @@ export const makeTweets = async (
           return { mediaUrl, sizes, type: mediaType };
         })
       : undefined;
-    return { content, media, id, createdAt, iconUrl, userid, dataid, username };
+    return {
+      content,
+      media,
+      id,
+      createdAt,
+      iconUrl,
+      userid,
+      dataid,
+      username,
+      listId,
+    };
   });
 };

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -20,6 +20,7 @@ interface Tweet {
   content: string;
   createdAt: string;
   media?: Media[];
+  listId: string;
 }
 
 interface TweetColumns {
@@ -31,19 +32,20 @@ interface TweetColumns {
   content: string;
   created_at: string;
   media?: MediaColumns[];
+  list_id: string;
 }
 
 interface Configs {
-  lastTweetId: number;
-  newestTweetDataId: string;
+  lastTweetIdGroup: Record<string, number>;
+  newestTweetDataIdGroup: Record<string, string>;
   listIds: string[];
   currentList: string;
 }
 
 interface ConfigColumns {
   id: 0;
-  last_tweet_id: number;
-  newest_tweet_data_id: string;
+  last_tweet_id_group: Record<string, number>;
+  newest_tweet_data_id_group: Record<string, string>;
   list_ids: string[];
   current_list: string;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "moduleResolution": "node",
-    "lib": ["ES6", "DOM"],
+    "lib": ["ES6", "DOM","ES2019"],
     "types": ["node","jest"],
     "typeRoots": ["node_modules/@types"],
     "experimentalDecorators": true,


### PR DESCRIPTION
#50 への対応。
list_idの追加に伴い、キャッシュのデータ構造からロジック、ステートの持ち方までかなりの部分を改変した。
特に、バックエンドから送られてくるTweetのデータにList_idが付与されているので、サンプルを更新せずに過去のサンプルを使いまわしているとエラーが起こることを確認した。
なお、list_idを書き込む部分について、メモ化が甘く、速度を低下させる恐れのあるコードが存在するが、これはいずれコンフィグのキャッシュの書き込み部分を書くときにdispatchに移すので、今はそのままにしている。