### PR TITLE
Feature/#85 bug shift screen fix

### DIFF
--- a/src/frontend/components/TimeLine/TimeLine.tsx
+++ b/src/frontend/components/TimeLine/TimeLine.tsx
@@ -12,7 +12,7 @@ export const TimeLine: React.FC = React.memo((_props) => {
   const classes = useStyles();
   return (
     <div className={classes.root}>
-      {isLoading && "Loading..."}
+      {tweets == null && isLoading && "Loading..."}
       {tweets != null &&
         tweets.length > 0 &&
         tweets.map((e, i) => <Tweet key={i} tweet={e} />)}

--- a/src/frontend/components/Tweet/Tweet.tsx
+++ b/src/frontend/components/Tweet/Tweet.tsx
@@ -21,7 +21,7 @@ export const Tweet: React.FC<{ tweet: Tweet }> = React.memo((props) => {
         </div>
         <div className={classes.tweetContent}>{props.tweet.content}</div>
       </div>
-      <div>{makeMediaElement(props.tweet, classes.media)}</div>
+      {makeMediaElement(props.tweet, classes.media)}
     </div>
   );
 });
@@ -30,9 +30,13 @@ const makeMediaElement = (tweet: Tweet, className: string) => {
   if (tweet.media == null) return;
   switch (tweet.media.type) {
     case "photo": {
-      return tweet.media.mediaUrl.map((e, i) => (
-        <img src={e} key={i} className={className} />
-      ));
+      return (
+        <div>
+          {tweet.media.mediaUrl.map((e, i) => (
+            <img src={e} key={i} className={className} />
+          ))}
+        </div>
+      );
     }
     case "animated_gif": {
       return;


### PR DESCRIPTION
#85 への対応。
結論としては、原因はTweetのLoading状態の表示だったので、ツイートが存在しているときは表示しないようにした。
また、空divは原因でこそないものの、消して損はないので削除することにした。